### PR TITLE
Mobile screen changes

### DIFF
--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -2074,5 +2074,10 @@ contributors = [
     fullname: "Yajnesh Kumar",
     username: "https://github.com/yajneshkumar790",
   },
+  {
+    id: 428,
+    fullname: "Harry Pattani",
+    username: "https://github.com/pattaniharry",
+  },
   
 ];

--- a/css/contributors.css
+++ b/css/contributors.css
@@ -135,6 +135,8 @@ body {
   box-shadow: none;
 }
 @media (max-width: 768px) {
+#stats{flex-direction: column;}
+
   .form-control,
   .form-control:focus,
   .from-control:active {

--- a/index.html
+++ b/index.html
@@ -73,13 +73,14 @@
     <!-- Main Content -->
     <div class="content">
         <div class="container">
+            <div class="header_wrapper text-sm-center">
             <span class="heading"><b>CONTRIBUTORS</b> </span>
             <div class="heart"></div>
             <div class="tdnn">
                 <div class="moon"></div>
             </div>
-            <div class="d-flex justify-content-between align-items-center">
-                <p class="rubberBand delay-4s">Add yourself to the list if you contribute.</p>
+            <div class="d-flex justify-content-between align-items-center flex-column flex-sm-row p-2 ">
+                <p class="rubberBand delay-4s p-2">Add yourself to the list if you contribute.</p>
                 <div class="inputs mr-3">
                     <i class="fa fa-search"></i>
                     <input type="text" id="search" class="form-control" placeholder="Search Contributors..">
@@ -91,6 +92,7 @@
                     Get "HacktoberFest-Accepted" label, Star ✩ the repo </a>
             </div>
             <hr style="width:90%">
+            </div>
         </div>
         <div class="container-fluid">
             <!-- Contributors will be displayed here -->

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     <div class="footer mt-auto py-3 bg-light text-center">
         <div class="container">
             <span class="text-muted">
-                <div id="stats"></div>
+                <div id="stats" ></div>
             </span>
         </div>
     </div>


### PR DESCRIPTION
# problem

style changes in mobile screen for better user interface 

# Solution

created a `header wrapper div` that wrapes the whole header,
`text-center` the main heading as it looks cleaner,
in mobile view added a `flex` and `padding` box to make it look better.

## Changes Proposed
List the main changes in the PR.
 
- `1.` created class `header-wrapper`
- `2.`Added `text-center` to class `header-wrapper`
- `3.` added `flex-column flex-sm-row p2` for better view in mobile screen
- `4.` added `flex-direction column` to id stats in @mediaquery max width 768

## other changes


- Refactored CSS for clarity.
