### PR TITLE
Fix task removal and selection handling in todoapp.py

### DIFF
--- a/Program's_Contributed_By_Contributors/Python_Programs/todoapp.py
+++ b/Program's_Contributed_By_Contributors/Python_Programs/todoapp.py
@@ -45,9 +45,11 @@ class TodoListApp(QMainWindow):
     def remove_task(self):
         selected_index = self.task_list.currentIndex()
         if selected_index.isValid():
-            task = self.tasks[selected_index.row()]
-            self.tasks.remove(task)
+            row = selected_index.row()
+            self.tasks.pop(row)
             self.update_task_list()
+            self.task_list.clearSelection()
+
 
     def update_task_list(self):
         self.task_list.setModel(QStringListModel(self.tasks))


### PR DESCRIPTION
- Replaced task removal logic with `pop()` to remove tasks by row index.
- Added `clearSelection()` after task removal to reset list view selection.
- Ensured correct index handling and UI update when removing tasks.
