### PR TITLE
fix: hacktober accepted button href and aria-label

### DIFF
--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -2074,5 +2074,9 @@ contributors = [
     fullname: "Yajnesh Kumar",
     username: "https://github.com/yajneshkumar790",
   },
-  
+  {
+    id: 428,
+    fullname: "Kang Abbad",
+    username: "https://github.com/KangAbbad",
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
                 </div>
             </div>
             <div>
-                <a class="github-button" href="https://github.com/fineanmol/Hacktoberfest2023" data-icon="octicon-star"
-                    data-size="large" data-show-count="true" aria-label="Star fineanmol/Hacktoberfest2023 on GitHub">To
+                <a class="github-button" href="https://github.com/fineanmol/Hacktoberfest2024" data-icon="octicon-star"
+                    data-size="large" data-show-count="true" aria-label="Star fineanmol/Hacktoberfest2024 on GitHub">To
                     Get "HacktoberFest-Accepted" label, Star ✩ the repo </a>
             </div>
             <hr style="width:90%">
@@ -144,5 +144,4 @@
     <script src="./contributors/contributorsList.js"></script>
     <script src="./scripts/main.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
# Problem
'Get "HacktoberFest-Accepted" label, Star ✩ the repo' button got wrong href link and aria-label

# Solution
- Update link in href property.
- Update aria-label button

## Changes Proposed
List the main changes in the PR.

- `1.` Update `href: https://github.com/fineanmol/Hacktoberfest2023` to `href: https://github.com/fineanmol/Hacktoberfest2024`.
- `2.` Update `aria-label="Star fineanmol/Hacktoberfest2023 on GitHub"` to  `aria-label="Star fineanmol/Hacktoberfest2024 on GitHub"`.

## Other Changes
-
