### PR TITLE
Update README.md + contrib.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,5 @@ Many candidates get attracted to Hacktoberfest for the swags. After 4 successful
 ## Our Top Contributors 
 
 <p align="center"><a href="https://github.com/fineanmol/Hacktoberfest2024/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=fineanmol/Hacktoberfest2024" max={1000} columns={100} anon={1}/>
+  <img src="https://contrib.rocks/image?repo=fineanmol/Hacktoberfest2024&columns=100&max=1000&anon=1"/>
 </a></p>


### PR DESCRIPTION
updated the contrib.rocks url to show contributors as you originally wished. The parameters need to be passed inside the image Url.

# Problem
the contributors were not being shown as you intended in the contrib.rocks code in readme raw

# Solution

The parameters need to be passed inside the image Url.

## Changes Proposed

<img src="https://contrib.rocks/image?repo=fineanmol/Hacktoberfest2024" max={1000} columns={100} anon={1}/>
WRONG ❌

<img src="https://contrib.rocks/image?repo=fineanmol/Hacktoberfest2024&columns={100}&max=1000&anon={1}"/>
RIGHT ✔️

## Other Changes
P.S.
please merge under hacktoberfest-accepted.
