### PR TITLE
pdftoimg.py

### DIFF
--- a/pdftoimg.py
+++ b/pdftoimg.py
@@ -1,0 +1,10 @@
+# PDF to Images
+
+import fitz
+
+pdf = 'sample_pdf.pdf'
+doc = fitz.open(pdf)
+
+for page in doc:
+    pix = page.getPixmap(alpha=False)
+    pix.writePNG('page-%i.png' % page.number)


### PR DESCRIPTION
In this program, we opened the image in binary mode. Non-text files must be open in this mode. The height of the image is at 164th position followed by width of the image. Both are 2 bytes long.

Note that this is true only for JPEG File Interchange Format (JFIF) standard. If your image is encode using other standard (like EXIF), the code will not work.

We convert the 2 bytes into a number using bitwise shifting operator <<. Finally, the resolution is displayed.


