### PR TITLE
Fix the footer padding at bottom issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     </style>
 </head>
 
-<body>
+<body style="padding: 0px;">
 
     <!-- Back-to-top Button -->
     <button id="back-to-top-btn"><i class="fas fa-angle-double-up"></i></button>


### PR DESCRIPTION
# Solving Issue #8028 
The footer is not at the bottom of the website. There is some space between the bottom of the website and the footer.

Example:
Before
![Screenshot from 2024-10-25 14-03-12](https://github.com/user-attachments/assets/ac4d71bc-e5ee-45a7-84f1-4adb045bd7a0)

After
![Screenshot from 2024-10-25 14-12-54](https://github.com/user-attachments/assets/7adc051f-1475-4fba-8dc0-f00d9ef03a75)
