### PR TITLE
Added colour of each social media icon upon hover #8080

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -135,8 +135,24 @@ footer {
   transition: color .4s ease;
 }
 
-.socials a:hover i {
-  color: aqua;
+.socials a[href*="facebook.com"]:hover i {
+  color: #3b5998;
+  filter: drop-shadow(0 0 1rem #a5c1ff);
+}
+
+.socials a[href*="twitter.com"]:hover i {
+  color: #1DA1F2;
+  filter: drop-shadow(0 0 1rem #89cef8);
+}
+
+.socials a[href*="instagram.com"]:hover i {
+  color: #C13584;
+  filter: drop-shadow(0 0 1rem #ffa5d8);
+}
+
+.socials a[href*="linkedin.com"]:hover i {
+  color: #0077b5;
+  filter: drop-shadow(0 0 1rem #83d3ff);
 }
 
 .footer-bottom {


### PR DESCRIPTION

## Changes Proposed
List the main changes in the PR.

- `1.` Added `.socials a[href*="facebook.com"]:hover i {
  color: #3b5998;
  filter: drop-shadow(0 0 1rem #a5c1ff);
}

.socials a[href*="twitter.com"]:hover i {
  color: #1DA1F2;
  filter: drop-shadow(0 0 1rem #89cef8);
}

.socials a[href*="instagram.com"]:hover i {
  color: #C13584;
  filter: drop-shadow(0 0 1rem #ffa5d8);
}

.socials a[href*="linkedin.com"]:hover i {
  color: #0077b5;
  filter: drop-shadow(0 0 1rem #83d3ff);
}'
<img width="531" alt="Screenshot 2024-10-29 at 12 31 35 AM" src="https://github.com/user-attachments/assets/74622650-6e55-4d90-9240-0438ffae6c09">
<img width="512" alt="Screenshot 2024-10-29 at 12 31 43 AM" src="https://github.com/user-attachments/assets/d72d4a0d-0b23-4c7b-aa67-bfa446d08c3c">
<img width="464" alt="Screenshot 2024-10-29 at 12 31 50 AM" src="https://github.com/user-attachments/assets/beb0bc32-1da0-4347-b05e-9b03d35a52fe">
<img width="536" alt="Screenshot 2024-10-29 at 12 31 55 AM" src="https://github.com/user-attachments/assets/79176dc8-b979-41f9-b948-dba290fb94ba">

