### PR TITLE
Update animation.css

### DIFF
--- a/css/animation.css
+++ b/css/animation.css
@@ -11,18 +11,28 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
   height: 160px;
-  overflow:hidden;
-  
+  overflow: hidden;
   font-family: 'Lato', sans-serif;
   font-size: 35px;
   line-height: 40px;
   color: #ecf0f1;
-  
+
   &__container {
     font-weight: 600;
     overflow: hidden;
     height: 40px;
     padding: 0 40px;
+    position: relative;
+
+    &:before,
+    &:after {
+      position: absolute;
+      top: 0;
+      font-size: 42px;
+      line-height: 40px;
+      color: #16a085;
+      animation: opacity 2s infinite;
+    }
 
     &:before {
       content: '[';
@@ -31,24 +41,7 @@ body {
 
     &:after {
       content: ']';
-      position: absolute;
       right: 0;
-    }
-
-    &:after, &:before {
-      position: absolute;
-      top: 0;
-      
-      color: #16a085;
-      font-size: 42px;
-      line-height: 40px;
-      
-      -webkit-animation-name: opacity;
-      -webkit-animation-duration: 2s;
-      -webkit-animation-iteration-count: infinite;
-      animation-name: opacity;
-      animation-duration: 2s;
-      animation-iteration-count: infinite;
     }
 
     &__text {
@@ -62,75 +55,27 @@ body {
       padding-left: 110px;
       text-align: left;
       list-style: none;
-      
-      -webkit-animation-name: change;
-      -webkit-animation-duration: 10s;
-      -webkit-animation-iteration-count: infinite;
-      animation-name: change;
-      animation-duration: 10s;
-      animation-iteration-count: infinite;
+      animation: change 10s infinite;
 
       &__item {
-        line-height:40px;
-        margin:0;
+        line-height: 40px;
+        margin: 0;
       }
     }
   }
 }
 
-@-webkit-keyframes opacity {
-  0%, 100% {opacity:0;}
-  50% {opacity:1;}
-}
-
-@-webkit-keyframes change {
-  0%, 12.66%, 100% {transform:translate3d(0,0,0);}
-  16.66%, 29.32% {transform:translate3d(0,-25%,0);}
-  33.32%,45.98% {transform:translate3d(0,-50%,0);}
-  49.98%,62.64% {transform:translate3d(0,-75%,0);}
-  66.64%,79.3% {transform:translate3d(0,-50%,0);}
-  83.3%,95.96% {transform:translate3d(0,-25%,0);}
-}
-
-@-o-keyframes opacity {
-  0%, 100% {opacity:0;}
-  50% {opacity:1;}
-}
-
-@-o-keyframes change {
-  0%, 12.66%, 100% {transform:translate3d(0,0,0);}
-  16.66%, 29.32% {transform:translate3d(0,-25%,0);}
-  33.32%,45.98% {transform:translate3d(0,-50%,0);}
-  49.98%,62.64% {transform:translate3d(0,-75%,0);}
-  66.64%,79.3% {transform:translate3d(0,-50%,0);}
-  83.3%,95.96% {transform:translate3d(0,-25%,0);}
-}
-
-@-moz-keyframes opacity {
-  0%, 100% {opacity:0;}
-  50% {opacity:1;}
-}
-
-@-moz-keyframes change {
-  0%, 12.66%, 100% {transform:translate3d(0,0,0);}
-  16.66%, 29.32% {transform:translate3d(0,-25%,0);}
-  33.32%,45.98% {transform:translate3d(0,-50%,0);}
-  49.98%,62.64% {transform:translate3d(0,-75%,0);}
-  66.64%,79.3% {transform:translate3d(0,-50%,0);}
-  83.3%,95.96% {transform:translate3d(0,-25%,0);}
-}
-
+// Keyframes for animations
 @keyframes opacity {
-  0%, 100% {opacity:0;}
-  50% {opacity:1;}
+  0%, 100% { opacity: 0; }
+  50% { opacity: 1; }
 }
 
 @keyframes change {
-  0%, 12.66%, 100% {transform:translate3d(0,0,0);}
-  16.66%, 29.32% {transform:translate3d(0,-25%,0);}
-  33.32%,45.98% {transform:translate3d(0,-50%,0);}
-  49.98%,62.64% {transform:translate3d(0,-75%,0);}
-  66.64%,79.3% {transform:translate3d(0,-50%,0);}
-  83.3%,95.96% {transform:translate3d(0,-25%,0);}
+  0%, 12.66%, 100% { transform: translate3d(0, 0, 0); }
+  16.66%, 29.32% { transform: translate3d(0, -25%, 0); }
+  33.32%, 45.98% { transform: translate3d(0, -50%, 0); }
+  49.98%, 62.64% { transform: translate3d(0, -75%, 0); }
+  66.64%, 79.3% { transform: translate3d(0, -50%, 0); }
+  83.3%, 95.96% { transform: translate3d(0, -25%, 0); }
 }
-


### PR DESCRIPTION
**Key Changes**
Removed Repeated Vendor Prefixes: In many cases, newer browsers no longer require vendor prefixes. You can add them back if supporting older browsers.
Combined &:before and &:after styles: Moved shared styles into a single selector.
Consistent Animation Names: Standardized the opacity and change animations across all browsers.